### PR TITLE
options object / preserveDrawingBuffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,6 @@ var renderFallback = function(canvas, videoFrame) {
 }
 
 function setupCanvas(canvas, vlc, options) {
-    console.log ('canvas', options);
     if (!options.fallbackRenderer)
         canvas.gl = canvas.getContext("webgl", {
             preserveDrawingBuffer:      Boolean (options.preserveDrawingBuffer)

--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ module.exports = {
         else
             options = {};
 
-        var vlc = require("wcjs-prebuilt").createPlayer(params);
+        var vlc = require("webchimera.js").createPlayer(params);
 
         var drawLoop, newFrame;
 


### PR DESCRIPTION
I've been generating thumbnails for video files with webchimera and needed to support the `preserveDrawingBuffer` option for `getContext`. This lets you work with the canvas' frame data using normal canvas methods.

This pull request shouldn't break any code but adds the following invocation option:

``` javascript
var chimera = require ('wcjs-renderer');
chimera.init (myCanvas, [], {
  fallbackRenderer: false,
  preserveDrawingBuffer: true
});
```
