### PR TITLE
Remove web chimera dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,17 @@ HTML:
 JS:
 ```
 var renderer = require("wcjs-renderer");
-var wcjs = require("wcjs-prebuilt");
-var vlcFlags = [/* Add VLC flags here */];
+var vlc = require("wcjs-prebuilt").createPlayer();
 var options = { /* Add renderer options here */ }
-var player = renderer.init(document.getElementById("canvas"), wcjs, vlcFlags, options);
-player.play("http://archive.org/download/CartoonClassics/Krazy_Kat_-_Keeping_Up_With_Krazy.mp4");
+renderer.init(document.getElementById("canvas"), vlc, options);
+vlc.play("http://archive.org/download/CartoonClassics/Krazy_Kat_-_Keeping_Up_With_Krazy.mp4");
 ```
 
 ### JavaScript API
 
-- ``init(canvas, wcjs, vlcFlags, options)``: initiate the renderer:
-``canvas`` can be a DOM node or selector (mandatory) 
-``wcjs`` is a WebChimera.js instance ex: wcjs-prebuilt (mandatory)
-``vlcFlags`` is an array of vlc parameters (optional), 
-``options`` is a object mentioning if the fallback non-WebGL renderer should be used (optional),
+- ``bind(vlc, canvas, options)``: bind the Webchimera VLC player to a canvas element:
+    - ``canvas`` can be a DOM node or selector (mandatory) 
+    - ``vlc`` is a VLC player created with WebChimera.js (mandatory)
+    - ``options`` is a object mentioning if the fallback non-WebGL renderer should be used (optional),
 
-- ``clearCanvas()``: draws a single black frame on the canvas, should be used after stopping the player and/or when the media file has changes (otherwise the frame from the previous video will be kept on the canvas)
+- ``clear(canvas)``: draws a single black frame on a canvas element

--- a/README.md
+++ b/README.md
@@ -18,17 +18,20 @@ HTML:
 ```
 JS:
 ```
-var wcjs = require("wcjs-renderer");
-var player = wcjs.init(document.getElementById("canvas"));
+var renderer = require("wcjs-renderer");
+var wcjs = require("wcjs-prebuilt");
+var vlcFlags = [/* Add VLC flags here */];
+var options = { /* Add renderer options here */ }
+var player = renderer.init(document.getElementById("canvas"), wcjs, vlcFlags, options);
 player.play("http://archive.org/download/CartoonClassics/Krazy_Kat_-_Keeping_Up_With_Krazy.mp4");
 ```
 
 ### JavaScript API
 
-- ``init( canvas, vlcArgs, fallbackRenderer, wcjsPrebuiltDep )``: initiate the renderer:
+- ``init(canvas, wcjs, vlcFlags, options)``: initiate the renderer:
 ``canvas`` can be a DOM node or selector (mandatory) 
-``vlcArgs`` is an array of vlc parameters (optional), 
+``wcjs`` is a WebChimera.js instance ex: wcjs-prebuilt (mandatory)
+``vlcFlags`` is an array of vlc parameters (optional), 
 ``options`` is a object mentioning if the fallback non-WebGL renderer should be used (optional),
-``wcjsPrebuiltDep`` is a WebChimera.js instance ex: wcjs-prebuilt (optional)
 
 - ``clearCanvas()``: draws a single black frame on the canvas, should be used after stopping the player and/or when the media file has changes (otherwise the frame from the previous video will be kept on the canvas)

--- a/index.js
+++ b/index.js
@@ -201,7 +201,6 @@ module.exports = {
                     drawLoop = null;
                 }
         };
-        return vlc;
     },
 
     clear: function(canvas) {

--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ function frameSetup(canvas, width, height, pixelFormat) {
 }
 
 module.exports = {
-    init: function(canvas, wcjs, params, options) {
+    bind: function(canvas, vlc, options) {
 
         if( !options ) {
             options = {
@@ -151,14 +151,10 @@ module.exports = {
             };
         }
 
-        var vlc = wcjs.createPlayer(params);
-
         var drawLoop, newFrame;
 
         if (typeof canvas === 'string')
             canvas = window.document.querySelector(canvas);
-
-        this._canvas = canvas;
 
         setupCanvas(canvas, vlc, options);
 
@@ -208,8 +204,8 @@ module.exports = {
         return vlc;
     },
 
-    clearCanvas: function() {
-        var gl = this._canvas.gl,
+    clear: function(canvas) {
+        var gl = canvas.gl,
             arr1 = new Uint8Array(1),
             arr2 = new Uint8Array(1);
 
@@ -221,7 +217,5 @@ module.exports = {
         gl.v.fill(1, 1, arr2);
 
         gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
-    },
-
-    _canvas: false
+    }
 };

--- a/index.js
+++ b/index.js
@@ -142,9 +142,7 @@ function frameSetup(canvas, width, height, pixelFormat) {
 }
 
 module.exports = {
-    init: function(canvas, params, options, wcjs) {
-
-        wcjs = wcjs ? wcjs : require("webchimera.js");
+    init: function(canvas, wcjs, params, options) {
 
         if( !options ) {
             options = {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,5 @@
     "repository": {
         "type": "git",
         "url": "https://github.com/Magics-Group/wcjs-renderer"
-    },
-    "optionalDependencies": {
-        "webchimera.js": "latest"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "wcjs-renderer",
     "description": "renderer for WebChimera.js",
-    "version": "2.0.0",
+    "version": "1.0.0",
     "license": "MIT",
     "author": "Sergey Radionov <rsatom@gmail.com>",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "wcjs-renderer",
     "description": "renderer for WebChimera.js",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "license": "MIT",
     "author": "Sergey Radionov <rsatom@gmail.com>",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "wcjs-renderer",
     "description": "renderer for WebChimera.js",
-    "version": "0.1.10",
+    "version": "1.0.0",
     "license": "MIT",
     "author": "Sergey Radionov <rsatom@gmail.com>",
     "keywords": [


### PR DESCRIPTION
Since the developer can choose how they want to supply their `wcjs` instance (using `webchimera.js`, or with `wcjs-prebuilt`), removing `webchimera.js` from the dependencies and simply making the `wcjs` parameter mandatory in the API seems quite sensible...

An argument for this is that for developers planning on using `wcjs-prebuilt`, having `npm` install `webchimera.js` makes little sense...
