### PR TITLE
Add callbacks corresponding to the VLC callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ vlc.play("http://archive.org/download/CartoonClassics/Krazy_Kat_-_Keeping_Up_Wit
 
 ### JavaScript API
 
-- ``bind(vlc, canvas, options)``: bind the Webchimera VLC player to a canvas element:
-    - ``canvas`` can be a DOM node or selector (mandatory) 
-    - ``vlc`` is a VLC player created with WebChimera.js (mandatory)
-    - ``options`` is a object mentioning if the fallback non-WebGL renderer should be used (optional),
+- `bind(vlc, canvas, options)`: bind the Webchimera VLC player to a canvas element:
+    - `canvas` can be a DOM node or selector (mandatory) 
+    - `vlc` is a VLC player created with WebChimera.js (mandatory)
+    - `options`:
+        - `fallbackRenderer` is a boolean mentioning if the fallback non-WebGL renderer should be used (optional, defaults to false),
+        - `preserveDrawingBuffer` is a boolean mentioning if we should preserve the drawing buffer (optional, defaults to false),
+        - `onFrameSetup` will be called when VLC's `onFrameSetup` callback is called, with the same arguments, after the canvas has been setup.
 
-- ``clear(canvas)``: draws a single black frame on a canvas element
+- `clear(canvas)`: draws a single black frame on a canvas element

--- a/README.md
+++ b/README.md
@@ -34,5 +34,7 @@ vlc.play("http://archive.org/download/CartoonClassics/Krazy_Kat_-_Keeping_Up_Wit
         - `fallbackRenderer` is a boolean mentioning if the fallback non-WebGL renderer should be used (optional, defaults to false),
         - `preserveDrawingBuffer` is a boolean mentioning if we should preserve the drawing buffer (optional, defaults to false),
         - `onFrameSetup` will be called when VLC's `onFrameSetup` callback is called, with the same arguments, after the canvas has been setup.
+        - `onFrameReady` will be called when VLC's `onFrameReady` callback is called, with the same arguments, after the frame has been rendered to the canvas.
+        - `onFrameCleanup` will be called when VLC's `onFrameCleanup` callback is called, with the same arguments, after the frame was cleaned up.
 
 - `clear(canvas)`: draws a single black frame on a canvas element

--- a/index.js
+++ b/index.js
@@ -158,7 +158,7 @@ module.exports = {
                 var draw = function() {
                     drawLoop = window.requestAnimationFrame(function() {
                         var gl = canvas.gl;
-                        if (newFrame) gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+                        if (gl && newFrame) gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
                         newFrame = false;
                         draw();
                     });

--- a/index.js
+++ b/index.js
@@ -186,6 +186,7 @@ module.exports = {
             function(videoFrame) {
                 (canvas.gl ? render : renderFallback)(canvas, videoFrame);
                 newFrame = true;
+                typeof options.onFrameReady === "function" && options.onFrameReady(videoFrame);
         };
         vlc.onFrameCleanup =
             function() {
@@ -193,6 +194,7 @@ module.exports = {
                     window.cancelAnimationFrame(drawLoop);
                     drawLoop = null;
                 }
+                typeof options.onFrameCleanup === "function" && options.onFrameCleanup();
         };
     },
 

--- a/index.js
+++ b/index.js
@@ -143,14 +143,6 @@ function frameSetup(canvas, width, height, pixelFormat) {
 
 module.exports = {
     bind: function(canvas, vlc, options) {
-
-        if( !options ) {
-            options = {
-                fallbackRenderer: false,
-                preserveDrawingBuffer: false
-            };
-        }
-
         var drawLoop, newFrame;
 
         if (typeof canvas === 'string')
@@ -161,6 +153,7 @@ module.exports = {
         vlc.onFrameSetup =
             function(width, height, pixelFormat) {
                 frameSetup(canvas, width, height, pixelFormat);
+                typeof options.onFrameSetup === "function" && options.onFrameSetup(width, height, pixelFormat);
 
                 var draw = function() {
                     drawLoop = window.requestAnimationFrame(function() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "wcjs-renderer",
     "description": "renderer for WebChimera.js",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "license": "MIT",
     "author": "Sergey Radionov <rsatom@gmail.com>",
     "keywords": [


### PR DESCRIPTION
If I understand correctly, with VLC you can only have 1 callback for the various events (using event listeners would be better, but we don't have this option yet). `wcjs-renderer` consumes some of these callbacks, leaving no option for the developer to subscribe to them. This commit offers the ability to specify custom callbacks and have wcjs-renderer fire them.

I've also used the opportunity to fix a bug where `gl.drawArrays` was called without ensuring that `gl` was actually defined. Quite critical when WebGL isn't available...
